### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
       "name": "Tommy Messbauer"
   }],
   "main": "./guid",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/dandean/guid/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "ender": "./ender.js",
   "devDependencies": {
     "mocha": "~1.14.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
